### PR TITLE
Add docker-compose-rabbitmq.yml for RabbitMQ integration

### DIFF
--- a/Thor.sln
+++ b/Thor.sln
@@ -19,6 +19,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "solution items", "solution 
 		Directory.Build.props = Directory.Build.props
 		docker-compose.yml = docker-compose.yml
 		README.md = README.md
+		docker-compose-rabbitmq.yml = docker-compose-rabbitmq.yml
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Thor.OpenAI", "src\extensions\Thor.OpenAI\Thor.OpenAI.csproj", "{F0FB17C9-8355-44C6-8340-066BE93694D8}"

--- a/docker-compose-rabbitmq.yml
+++ b/docker-compose-rabbitmq.yml
@@ -1,0 +1,36 @@
+﻿version: '3.8'
+
+services:
+  ai-dotnet-api-service:
+    image: registry.token-ai.cn/thor:latest
+    ports:
+      - 18080:8080
+    build:
+      context: .
+      dockerfile: src/Thor.Service/Dockerfile
+    container_name: thor
+    volumes:
+      - ./data:/data
+    environment:
+      - TZ=Asia/Shanghai
+      - DBType=sqlite # sqlite | [postgresql,pgsql] | [sqlserver,mssql] | mysql
+      - ConnectionString=data source=/data/token.db
+      - LoggerConnectionString=data source=/data/logger.db
+      - CACHE_TYPE=Redis
+      - CACHE_CONNECTION_STRING=ai-redis
+      - RabbitMQ:ConnectionString=amqp://admin:admin@ai-rabbitmq:5672
+
+  ai-redis:
+    image: redis
+    container_name: ai-redis
+    volumes:
+      - ./data/redis:/data
+    command: redis-server --appendonly yes
+        
+
+  ai-rabbitmq:
+    image: rabbitmq:3-management
+    container_name: ai-rabbitmq
+    environment:
+      RABBITMQ_DEFAULT_USER: admin
+      RABBITMQ_DEFAULT_PASS: admin

--- a/src/Thor.Service/appsettings.json
+++ b/src/Thor.Service/appsettings.json
@@ -1,5 +1,4 @@
 {
-  "http_ports":"5045",
   "Logging": {
     "LogLevel": {
       "Default": "Information",
@@ -78,5 +77,6 @@
     "Properties": {
       "Application": "AI Gateway"
     }
-  }
+  },
+  "OTEL_EXPORTER_OTLP_ENDPOINT ": "http://20.205.21.95:4317/"
 }


### PR DESCRIPTION
This pull request introduces a new Docker Compose configuration for RabbitMQ, updates the solution file to include this new configuration, and modifies the application settings. The most important changes include adding the `docker-compose-rabbitmq.yml` file, updating `Thor.sln` to reference the new Docker Compose file, and modifying `appsettings.json` to include a new OpenTelemetry exporter endpoint.

### Docker Compose Configuration:

* Added a new `docker-compose-rabbitmq.yml` file to configure services for the AI .NET API, Redis, and RabbitMQ. (`docker-compose-rabbitmq.yml`)

### Solution File Update:

* Updated `Thor.sln` to include the new `docker-compose-rabbitmq.yml` file. (`Thor.sln`)

### Application Settings:

* Removed the `http_ports` setting from `appsettings.json`. (`src/Thor.Service/appsettings.json`)
* Added the `OTEL_EXPORTER_OTLP_ENDPOINT` setting to `appsettings.json` for OpenTelemetry configuration. (`src/Thor.Service/appsettings.json`)