### PR TITLE
chore: Update docker-compose-rabbitmq.yml and .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -489,3 +489,4 @@ $RECYCLE.BIN/
 /src/Thor.Service/logger.db
 /src/Thor.Service/logger.db-shm
 /src/Thor.Service/logger.db-wal
+/data

--- a/docker-compose-rabbitmq.yml
+++ b/docker-compose-rabbitmq.yml
@@ -9,6 +9,10 @@ services:
       context: .
       dockerfile: src/Thor.Service/Dockerfile
     container_name: thor
+    depends_on:
+      - ai-rabbitmq
+      - ai-redis
+      - postgres
     volumes:
       - ./data:/data
     environment:
@@ -20,6 +24,7 @@ services:
       - CACHE_CONNECTION_STRING=ai-redis
       - RabbitMQ:ConnectionString=amqp://admin:admin@ai-rabbitmq:5672
       - OTEL_SERVICE_NAME=Thor
+      - OTEL_EXPORTER_OTLP_PROTOCOL=grpc
       - OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889
 
   postgres:
@@ -42,10 +47,11 @@ services:
     command: redis-server --appendonly yes
 
   aspire-dashboard:
-    image: mcr.microsoft.com/dotnet/aspire-dashboard:8.1.0
+    image: mcr.microsoft.com/dotnet/aspire-dashboard:8.2
     container_name: aspire-dashboard
     ports:
       - "4317:18889"
+      - "18888:18888"
     environment:
       - TZ=Asia/Shanghai
       - Dashboard:ApplicationName=Aspire


### PR DESCRIPTION
This pull request includes several updates to the `docker-compose-rabbitmq.yml` file to improve service dependencies, environment configurations, and container images.

Service dependencies and environment configurations:

* Added `depends_on` entries for `ai-rabbitmq`, `ai-redis`, and `postgres` to the `thor` service to ensure these services start before `thor`. (`docker-compose-rabbitmq.yml`, [docker-compose-rabbitmq.ymlR12-R15](diffhunk://#diff-e425c25151f41f8ec06475e8db316f778b312b49d514883374f7a4a9a5c757fcR12-R15))
* Added the `OTEL_EXPORTER_OTLP_PROTOCOL` environment variable with the value `grpc` to the `thor` service configuration. (`docker-compose-rabbitmq.yml`, [docker-compose-rabbitmq.ymlR27](diffhunk://#diff-e425c25151f41f8ec06475e8db316f778b312b49d514883374f7a4a9a5c757fcR27))

Container images and ports:

* Updated the `aspire-dashboard` service image from version `8.1.0` to `8.2`. (`docker-compose-rabbitmq.yml`, [docker-compose-rabbitmq.ymlL45-R54](diffhunk://#diff-e425c25151f41f8ec06475e8db316f778b312b49d514883374f7a4a9a5c757fcL45-R54))
* Added port mapping `18888:18888` to the `aspire-dashboard` service to expose an additional port. (`docker-compose-rabbitmq.yml`, [docker-compose-rabbitmq.ymlL45-R54](diffhunk://#diff-e425c25151f41f8ec06475e8db316f778b312b49d514883374f7a4a9a5c757fcL45-R54))